### PR TITLE
Add Option to Respond as JSON or String

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ const pantry = require('pantry-node')
 
 const pantryID = "xxxx-xxxx-xxxx-xxxx-xxxx-xxxx"
 const pantryClient = new pantry(pantryID)
+const options = { parseJSON: true } // optional
 
 pantryClient.basket
-  .get('ToDoList')
+  .get('ToDoList', options)
   .then((contents) => console.log(contents))
 ```
 
@@ -55,6 +56,7 @@ const pantry = require('pantry-node')
 
 const pantryID = "xxxx-xxxx-xxxx-xxxx-xxxx-xxxx"
 const pantryClient = new pantry(pantryID)
+const options = { parseJSON: true } // optional
 
 // The new payload that you want your basket to have
 const payload = {
@@ -62,7 +64,7 @@ const payload = {
 }
 
 pantryClient.basket
-  .update('ToDoList', payload)
+  .update('ToDoList', payload, options)
   .then((response) => console.log(response))
 ```
 

--- a/dist/pantry.js
+++ b/dist/pantry.js
@@ -10,24 +10,25 @@
   const API_VERSION = '1';
 
   class Request {
-    static async get(route) {
-      return Request.perform(route, 'GET', 'json')
+    static async get(route, parseJSON = true) {
+      return Request.perform(route, 'GET', parseJSON)
     }
 
     static async post(route, payload) {
-      return Request.perform(route, 'POST', 'string', payload)
+      return Request.perform(route, 'POST', false, payload)
     }
 
-    static async put(route, payload) {
-      return Request.perform(route, 'PUT', 'json', payload)
+    static async put(route, payload, parseJSON = true) {
+      return Request.perform(route, 'PUT', parseJSON, payload)
     }
 
     static async delete(route) {
-      return Request.perform(route, 'DELETE', 'string')
+      return Request.perform(route, 'DELETE', false)
     }
 
-    static async perform(route, method, responseFormat, payload = {}) {
+    static async perform(route, method, parseJSON, payload = {}) {
       try {
+        const responseFormat = parseJSON ? 'json' : 'string';
         const action = bent(method, responseFormat);
         const response = await action(Request.path(route), payload);
         return response
@@ -45,18 +46,22 @@
   class Basket {
     constructor(pantryID) {
       this.pantryID = pantryID;
+      this.defaultOptions = {
+        parseJSON: true,
+      };
     }
 
-    update(basketName, payload) {
-      return Request.put(`${this.pantryID}/basket/${basketName}`, payload)
+    update(basketName, payload, { parseJSON } = this.defaultOptions) {
+      return Request.put(`${this.pantryID}/basket/${basketName}`, payload,
+        parseJSON)
     }
 
     create(basketName, payload = {}) {
       return Request.post(`${this.pantryID}/basket/${basketName}`, payload)
     }
 
-    get(basketName) {
-      return Request.get(`${this.pantryID}/basket/${basketName}`)
+    get(basketName, { parseJSON } = this.defaultOptions) {
+      return Request.get(`${this.pantryID}/basket/${basketName}`, parseJSON)
     }
 
     delete(basketName) {

--- a/src/resources/basket.js
+++ b/src/resources/basket.js
@@ -3,18 +3,22 @@ import Request from './request'
 export default class Basket {
   constructor(pantryID) {
     this.pantryID = pantryID
+    this.defaultOptions = {
+      parseJSON: true,
+    }
   }
 
-  update(basketName, payload) {
-    return Request.put(`${this.pantryID}/basket/${basketName}`, payload)
+  update(basketName, payload, { parseJSON } = this.defaultOptions) {
+    return Request.put(`${this.pantryID}/basket/${basketName}`, payload,
+      parseJSON)
   }
 
   create(basketName, payload = {}) {
     return Request.post(`${this.pantryID}/basket/${basketName}`, payload)
   }
 
-  get(basketName) {
-    return Request.get(`${this.pantryID}/basket/${basketName}`)
+  get(basketName, { parseJSON } = this.defaultOptions) {
+    return Request.get(`${this.pantryID}/basket/${basketName}`, parseJSON)
   }
 
   delete(basketName) {

--- a/src/resources/request.js
+++ b/src/resources/request.js
@@ -4,24 +4,25 @@ const BASE_PATH = 'https://getpantry.cloud'
 const API_VERSION = '1'
 
 export default class Request {
-  static async get(route) {
-    return Request.perform(route, 'GET', 'json')
+  static async get(route, parseJSON = true) {
+    return Request.perform(route, 'GET', parseJSON)
   }
 
   static async post(route, payload) {
-    return Request.perform(route, 'POST', 'string', payload)
+    return Request.perform(route, 'POST', false, payload)
   }
 
-  static async put(route, payload) {
-    return Request.perform(route, 'PUT', 'json', payload)
+  static async put(route, payload, parseJSON = true) {
+    return Request.perform(route, 'PUT', parseJSON, payload)
   }
 
   static async delete(route) {
-    return Request.perform(route, 'DELETE', 'string')
+    return Request.perform(route, 'DELETE', false)
   }
 
-  static async perform(route, method, responseFormat, payload = {}) {
+  static async perform(route, method, parseJSON, payload = {}) {
     try {
+      const responseFormat = parseJSON ? 'json' : 'string'
       const action = bent(method, responseFormat)
       const response = await action(Request.path(route), payload)
       return response


### PR DESCRIPTION
A user suggested having a configurable flag dictate if the response of a
GET (basket) request be a JSON object or a string.

This change addresses the need by:
* Introducing a parseJSON option to GET & PUT basket methods which will
  allow the user to receive a response in their preferred manner.
  Defaults to false.

Resolves https://github.com/imRohan/pantry-node/issues/1